### PR TITLE
Fix compile on windows with clang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,12 @@ Thumbs.db
 # Build directory
 # ---------------
 build/*
+
+# generated config
+config.h
+
+# clangd cache
+.cache/
+
+# VScode IDE files
+.vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,5 +21,9 @@ add_executable (unshieldv3
 	ISArchiveV3.cpp
 	blast.c
 )
-target_link_libraries(unshieldv3 stdc++fs)
+
+target_link_libraries(unshieldv3)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+	target_link_libraries(stdc++fs)
+endif()
 install(TARGETS unshieldv3)

--- a/ISArchiveV3.cpp
+++ b/ISArchiveV3.cpp
@@ -17,6 +17,8 @@ limitations under the License.
 #include "ISArchiveV3.h"
 #include <algorithm>
 #include <cassert>
+#include <sstream>
+#include <string>
 #include <iostream>
 #include <exception>
 extern "C" {
@@ -111,8 +113,10 @@ std::tm ISArchiveV3::File::tm() const {
 
 std::filesystem::path ISArchiveV3::File::path() const {
     std::string fp = full_path;
+    // windows paths are wchar_t, convert
+    char pref_seperator = fs::path::preferred_separator;
     std::replace(fp.begin(), fp.end(),
-               '\\', fs::path::preferred_separator);
+            '\\', pref_seperator);
     return std::filesystem::path(fp);
 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -44,7 +44,7 @@ void info(const ISArchiveV3& archive) {
     }
 }
 
-void list(const ISArchiveV3& archive, bool verbose = false) {
+void list_archive(const ISArchiveV3& archive, bool verbose = false) {
     size_t max_path = 0;
     if (verbose) {
         for (auto& f : archive.files()) {
@@ -161,7 +161,7 @@ int cmd_list(deque<string> subargs) {
         return 1;
     }
     ISArchiveV3 archive(apath);
-    list(archive, verbose);
+    list_archive(archive, verbose);
     return 0;
 }
 


### PR DESCRIPTION
A few things:

- linking against `stdc++fs` is no longer required with clang and will end up throwing an error on newer versions. 
- `fs::path::preferred_seperator` is a `wchar_t` on windows, so you have to convert it to char first before replacing 
- `list()` in main.cpp conflicts with `std::list()`; renamed to `list_archive()`