### PR TITLE
No longer require linking to stdc++fs

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Print env
       run: |
@@ -40,7 +40,7 @@ jobs:
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest -C ${{env.BUILD_TYPE}}
       
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: unshieldv3.x86_64
         path: ${{github.workspace}}/build/unshieldv3

--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,12 @@ Thumbs.db
 # Build directory
 # ---------------
 build/*
+
+# generated config
+config.h
+
+# clangd cache
+.cache/
+
+# VScode IDE files
+.vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,4 @@ add_executable (unshieldv3
 )
 
 target_link_libraries(unshieldv3)
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-	target_link_libraries(stdc++fs)
-endif()
 install(TARGETS unshieldv3)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,5 +21,9 @@ add_executable (unshieldv3
 	ISArchiveV3.cpp
 	blast.c
 )
-target_link_libraries(unshieldv3 stdc++fs)
+
+target_link_libraries(unshieldv3)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+	target_link_libraries(stdc++fs)
+endif()
 install(TARGETS unshieldv3)

--- a/ISArchiveV3.cpp
+++ b/ISArchiveV3.cpp
@@ -17,6 +17,8 @@ limitations under the License.
 #include "ISArchiveV3.h"
 #include <algorithm>
 #include <cassert>
+#include <sstream>
+#include <string>
 #include <iostream>
 #include <exception>
 extern "C" {
@@ -111,8 +113,10 @@ std::tm ISArchiveV3::File::tm() const {
 
 std::filesystem::path ISArchiveV3::File::path() const {
     std::string fp = full_path;
+    // windows paths are wchar_t, convert
+    char pref_seperator = fs::path::preferred_separator;
     std::replace(fp.begin(), fp.end(),
-               '\\', fs::path::preferred_separator);
+            '\\', pref_seperator);
     return std::filesystem::path(fp);
 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -44,7 +44,7 @@ void info(const ISArchiveV3& archive) {
     }
 }
 
-void list(const ISArchiveV3& archive, bool verbose = false) {
+void list_archive(const ISArchiveV3& archive, bool verbose = false) {
     size_t max_path = 0;
     if (verbose) {
         for (auto& f : archive.files()) {
@@ -161,7 +161,7 @@ int cmd_list(deque<string> subargs) {
         return 1;
     }
     ISArchiveV3 archive(apath);
-    list(archive, verbose);
+    list_archive(archive, verbose);
     return 0;
 }
 


### PR DESCRIPTION
Also fix missing `#include<sstream>` required for `ostringstream`.

Tested on macos and ubuntu lts

