### PR TITLE
Fix build on Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,5 +21,4 @@ add_executable (unshieldv3
 	ISArchiveV3.cpp
 	blast.c
 )
-target_link_libraries(unshieldv3 stdc++fs)
 install(TARGETS unshieldv3)

--- a/ISArchiveV3.cpp
+++ b/ISArchiveV3.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 #include <algorithm>
 #include <cassert>
 #include <iostream>
+#include <sstream>
 #include <exception>
 extern "C" {
     #include "blast.h"


### PR DESCRIPTION
In Clang/libc++ including `<iostream>` is not enough to get the implementation of `ostringstream`. We need to include `<sstream>` as well.

Also, the inclusion of libstdc++fs should no longer be necessary, and doesn't work on Clang either. (This is already handled by the other two PRs to some degree, but I wanted to have a minimal patch that fixes all of the compilation errors I've seen.)